### PR TITLE
Align fs interface

### DIFF
--- a/storage/fs.go
+++ b/storage/fs.go
@@ -52,11 +52,9 @@ func Add(node StoragePeer, r io.Reader, cb cid.Builder, l layout) (ipld.Node, er
 		Dagserv: node.DagService(),
 		//RawLeaves:  true,
 		Maxlinks: helpers.DefaultLinksPerBlock,
-		NoCopy:     true,
+		//NoCopy:     true,
 		CidBuilder: cb,
 	}
-
-	// TODO encrypt stream
 
 	chnk, err := chunker.FromString(r, Chunker)
 	if err != nil {

--- a/storage/fs.go
+++ b/storage/fs.go
@@ -32,15 +32,30 @@ const (
 	DefaultHashFunc        = "sha2-256"
 )
 
+func AddDir(node StoragePeer) (ufsio.Directory, ipld.Node, error) {
+	dir := ufsio.NewDirectory(node.DagService())
+	dirnode, err := dir.GetNode()
+	return dir, dirnode, err
+}
+
+func LoadDir(node StoragePeer, c cid.Cid) (ufsio.Directory, error) {
+	dag := node.DagService()
+	n, err := dag.Get(node.Context(), c)
+	if err != nil {
+		return nil, err
+	}
+	return ufsio.NewDirectoryFromNode(dag, n)
+}
+
 // AddStream is suitable for large data
 // using trickle layout which is suitable for streaming
 func AddStream(node StoragePeer, r io.Reader, hfunc string) (ipld.Node, error) {
-	prefix, err := NewCidBuilder(hfunc)
+	cb, err := NewCidBuilder(hfunc)
 	if err != nil {
 		return nil, err
 	}
 
-	return Add(node, r, prefix, trickle.Layout)
+	return Add(node, r, cb, trickle.Layout)
 }
 
 // Add chunks and adds content to the DAGService from a reader.

--- a/storage/peer_test.go
+++ b/storage/peer_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"github.com/amirylm/libp2p-facade/core"
 	ipld "github.com/ipfs/go-ipld-format"
-	"github.com/ipfs/go-unixfs/importer/balanced"
 	"github.com/libp2p/go-libp2p-core/pnet"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -54,11 +53,11 @@ func TestStorageNode(t *testing.T) {
 
 func add(n StoragePeer, data string) (ipld.Node, error) {
 	r := bytes.NewReader([]byte(data))
-	cb, err := cidBuilder("")
+	cb, err := NewCidBuilder("")
 	if err != nil {
 		return nil, err
 	}
-	return Add(n, []byte{}, r, cb, balanced.Layout)
+	return Add(n, r, cb, nil)
 }
 
 func newStoragePeer(psk pnet.PSK) StoragePeer {

--- a/storage/peer_test.go
+++ b/storage/peer_test.go
@@ -64,14 +64,18 @@ func TestAddDir(t *testing.T) {
 
 	n0 := nodes[0].(StoragePeer)
 	dir, dirnode, err := AddDir(n0)
-	assert.Nil(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n0.Logger().Infof("dir created %s", dirnode.Cid().String())
 
 	plaintext := "Child data..."
 	name := "somedata"
 	datanode, err := add(n0, "Child data...")
 	assert.Nil(t, err)
-	err = dir.AddChild(n0.Context(), name, datanode)
+	dir, dirnode, err = AddToDir(n0, dir, name, datanode)
 	assert.Nil(t, err)
+	n0.Logger().Infof("data %s added to %s", datanode.Cid().String(), dirnode.Cid().String())
 
 	n1 := nodes[1].(StoragePeer)
 	dirN1, err := LoadDir(n1, dirnode.Cid())


### PR DESCRIPTION
1. Reducing the key from the interface, any stream encryption should be done outside of the library scope
2. Adding Directory management, using [ipfs/go-unixfs](https://github.com/ipfs/go-unixfs) so directories are immutable (not like in [ipfs/go-mfs](https://github.com/ipfs/go-mfs))