### PR TITLE
Logging

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -21,6 +21,7 @@ func NewKadDHT(ctx context.Context, host host.Host, protocolPrefix protocol.ID,
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "could not create DHT")
 	}
+	logger.Debugf("created Kademlia DHT with protocol prefix %s", string(protocolPrefix))
 	return kdht, libp2pdisc.NewRoutingDiscovery(kdht), nil
 }
 

--- a/facade.go
+++ b/facade.go
@@ -8,12 +8,17 @@ import (
 
 	"github.com/amirylm/libp2p-facade/config"
 	"github.com/amirylm/libp2p-facade/pubsub"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/routing"
 	libp2pdisc "github.com/libp2p/go-libp2p-discovery"
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
+)
+
+var (
+	logger = logging.Logger("p2p:facade")
 )
 
 type ConnectQueue chan peer.AddrInfo
@@ -63,6 +68,7 @@ func New(ctx context.Context, cfg *config.Config, opts ...libp2p.Option) (Facade
 	if err != nil {
 		return nil, err
 	}
+	logger.Info("created new libp2p host", h.ID().String(), h.Addrs())
 	f := facade{
 		ctx:  ctx,
 		host: h,
@@ -90,11 +96,14 @@ func New(ctx context.Context, cfg *config.Config, opts ...libp2p.Option) (Facade
 	if len(f.cfg.MdnsServiceTag) > 0 {
 		f.mdnsq = make(ConnectQueue)
 		f.mdnsSvc = NewMdns(ctx, f.mdnsq, f.host, f.cfg.MdnsServiceTag)
+		logger.Info("using mdns discovery, tag", f.cfg.MdnsServiceTag)
 	}
 
 	if cfg.Pubsub != nil {
 		err = f.setupPubsub()
 	}
+
+	logger.Debug("libp2p facade was created successfully")
 
 	return &f, err
 }

--- a/facade_test.go
+++ b/facade_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/amirylm/libp2p-facade/streams"
+	logging "github.com/ipfs/go-log/v2"
 	core "github.com/libp2p/go-libp2p-core"
 	"github.com/stretchr/testify/require"
 )
@@ -19,6 +20,7 @@ func TestStreams(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	require.NoError(t, logging.SetLogLevelRegex("p2p:.*", "info"))
 	n := 10
 	nodes := newLocalNetwork(ctx, t, n)
 

--- a/pubsub/subFilter.go
+++ b/pubsub/subFilter.go
@@ -25,12 +25,17 @@ type subFilter struct {
 
 // CanSubscribe implements pubsub.SubscriptionFilter
 func (sf *subFilter) CanSubscribe(topic string) bool {
-	return sf.reg.MatchString(topic)
+	if !sf.reg.MatchString(topic) {
+		logger.Debugf("sub-filter: topic %s doesn't match pattern", topic)
+		return false
+	}
+	return true
 }
 
 // FilterIncomingSubscriptions implements pubsub.SubscriptionFilter
 func (sf *subFilter) FilterIncomingSubscriptions(pi peer.ID, subs []*pb.RPC_SubOpts) ([]*pb.RPC_SubOpts, error) {
 	if len(subs) > sf.limit {
+		logger.Debugf("sub-filter: reached subscriptions limit %d", sf.limit)
 		return nil, libpubsub.ErrTooManySubscriptions
 	}
 

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -18,7 +18,7 @@ func TestPubsub(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logging.SetLogLevelRegex("p2p:.*", "info")
+	require.NoError(t, logging.SetLogLevelRegex("p2p:.*", "info"))
 	n := 10
 	nodes := newLocalNetwork(ctx, t, n)
 

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	logging "github.com/ipfs/go-log/v2"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/stretchr/testify/require"
 )
@@ -17,6 +18,7 @@ func TestPubsub(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	logging.SetLogLevelRegex("p2p:.*", "info")
 	n := 10
 	nodes := newLocalNetwork(ctx, t, n)
 

--- a/streams/handle.go
+++ b/streams/handle.go
@@ -19,7 +19,9 @@ func HandleStream(stream core.Stream, timeout time.Duration) ([]byte, RespondStr
 
 	metricStreamIn.WithLabelValues(string(protocol)).Inc()
 	s := NewStream(stream)
+	pid := stream.Conn().RemotePeer().String()
 	done := func() error {
+		logger.Debugf("closing stream %s, src peer: %s", string(protocol), pid)
 		return s.Close()
 	}
 	if timeout == 0 {
@@ -35,6 +37,7 @@ func HandleStream(stream core.Stream, timeout time.Duration) ([]byte, RespondStr
 			metricStreamInDone.WithLabelValues(string(protocol), "write").Inc()
 			return errors.Wrap(err, "could not write to stream")
 		}
+		logger.Debugf("handle stream success %s, src peer: %s", string(protocol), pid)
 		metricStreamInDone.WithLabelValues(string(protocol), "").Inc()
 		return nil
 	}

--- a/streams/request.go
+++ b/streams/request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
@@ -12,6 +13,10 @@ import (
 
 const (
 	DefaultTimeout = 15 * time.Second
+)
+
+var (
+	logger = logging.Logger("p2p:stream")
 )
 
 // StreamConfig is the config object required to make a request
@@ -49,6 +54,7 @@ func Request(peerID peer.ID, protocol protocol.ID, data []byte, cfg StreamConfig
 		metricStreamOutDone.WithLabelValues(string(protocol), "read").Inc()
 		return nil, errors.Wrap(err, "could not read stream msg")
 	}
+	logger.Debugf("successful stream request %s, target peer: %s", string(protocol), peerID.String())
 	metricStreamOutDone.WithLabelValues(string(protocol), "").Inc()
 	return res, nil
 }

--- a/test_utils.go
+++ b/test_utils.go
@@ -33,7 +33,7 @@ func newLocalNetwork(ctx context.Context, t *testing.T, n int) []Facade {
 func newLocalConfig(ctx context.Context, i, maxPeers int) *config.Config {
 	cfg := config.Config{
 		Routing: func(h host.Host) (routing.Routing, error) {
-			kad, _, err := NewKadDHT(ctx, h, "test.mdns", dht.ModeAutoServer, nil)
+			kad, _, err := NewKadDHT(ctx, h, "test.dht", dht.ModeAutoServer, nil)
 			return kad, err
 		},
 	}

--- a/test_utils.go
+++ b/test_utils.go
@@ -21,7 +21,7 @@ func newLocalNetwork(ctx context.Context, t *testing.T, n int) []Facade {
 	}
 	nodes, err := StartNodes(ctx, cfgs)
 	require.NoError(t, err)
-	require.Len(t, nodes, 10)
+	require.Len(t, nodes, n)
 
 	for _, f := range nodes {
 		require.NoError(t, commons.EnsureConnectedPeers(ctx, f.Host(), n/2, time.Second*8))


### PR DESCRIPTION
Added logging utility [ipfs/go-log](https://github.com/ipfs/go-log) and logs cross the project using subsystems namespaces for easy config from outside.

Using the following logger names:
- `p2p:facade`
- `p2p:pubsub`
- `p2p:stream` 